### PR TITLE
Clean up returns.

### DIFF
--- a/ftplugin/php_documentor.vim
+++ b/ftplugin/php_documentor.vim
@@ -149,7 +149,7 @@ let g:pdv_re_abstract = '\(abstract\)'
 let g:pdv_re_final = '\(final\)'
 
 " [:space:]*(private|protected|public|static|abstract)*[:space:]+[:identifier:]+\([:params:]\)
-let g:pdv_re_func = '^\s*\([a-zA-Z ]*\)function\s\+\([^ (]\+\)\s*(\s*\(.*\)\s*)\(\s*:\(.*\)\)\?\s*[{;]\?$'
+let g:pdv_re_func = '^\s*\([a-zA-Z ]*\)function\s\+\([^ (]\+\)\s*(\s*\(.*\)\s*)\(\s*:\s*\(\w*\)\)\?\s*[{;]\?$'
 
 " [:typehint:]*[:space:]*$[:identifier]\([:space:]*=[:space:]*[:value:]\)?
 let g:pdv_re_param = ' *\([^ &]*\) *&\?\$\([A-Za-z_][A-Za-z0-9_]*\) *=\? *\(.*\)\?$'


### PR DESCRIPTION
- Remove extra space after '@return'
- Don't capture '{' if return type and '{' are on the same line.

Example:
```php
class Test {
	private function heyo():array {

	}

	abstract public function get_thing() :string;
}

function blah() : bool {

}

function foo() {

}

function bar() :int
{

}
```

Result:
```php
class Test {
	/**
	 * heyo
	 *
	 *
	 * @return array
	 */
	private function heyo():array {

	}

	/**
	 * get_thing
	 *
	 *
	 * @return string
	 */
	abstract public function get_thing() :string;

/**
 * blah
 *
 * @access public
 *
 * @return bool
 */
function blah() : bool {

}

/**
 * foo
 *
 * @access public
 *
 * @return void
 */
function foo() {

}

/**
 * bar
 *
 * @access public
 *
 * @return int
 */
function bar() :int
{

}
```